### PR TITLE
improve CI/env checks for namespace module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zenlib"
-version = "3.1.2"
+version = "3.1.3"
 authors = [
   { name="Desultory", email="dev@pyl.onl" },
 ]

--- a/src/zenlib/__init__.py
+++ b/src/zenlib/__init__.py
@@ -1,12 +1,14 @@
 from .logging import ColorLognameFormatter, loggify
 from .types import NoDupFlatList, validatedDataclass
 from .util import colorize, check_dict, handle_plural, pretty_print, replace_file_line, update_init, walk_dict
+from .namespace import nsexec
 
 __all__ = [
     "colorize",
     "ColorLognameFormatter",
     "loggify",
     "handle_plural",
+    "nsexec",
     "NoDupFlatList",
     "validatedDataclass",
     "pretty_print",

--- a/src/zenlib/namespace/__init__.py
+++ b/src/zenlib/namespace/__init__.py
@@ -1,9 +1,12 @@
 from os import environ
-if not environ.get("CI"):
-    from .nsexec import nsexec
-    from .namespace import get_id_map
-else:
+from platform import system
+from sys import version_info
+
+if environ.get("CI", "false").lower() == "true" or version_info < (3, 12) or system() != "Linux":
     nsexec, get_id_map = None, None
+else:
+    from .namespace import get_id_map
+    from .nsexec import nsexec
 
 __all__ = [
     "nsexec",

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,7 +1,24 @@
 from os import environ
+from platform import system
+from sys import version_info
 from unittest import TestCase, main, skipIf
 
 from zenlib.namespace import nsexec
+
+
+def check_test_compat():
+    """Checks if tests are compatible with the current environment"""
+
+    if environ.get("CI", "false").lower() == "true":
+        return
+
+    if system() != "Linux":
+        return
+
+    if version_info < (3, 12):
+        return
+
+    return True
 
 
 class TestPassedException(Exception):
@@ -32,25 +49,21 @@ def test_cwd():
     return [p for p in Path("/").rglob("")]
 
 
+@skipIf(not check_test_compat(), "Skipping test_namespace.py in CI")
 class TestNamespace(TestCase):
-    @skipIf(environ.get("CI") == "true", "Skipping test_namespace.py in CI")
     def test_user_namespace_exceptions(self):
         with self.assertRaises(TestPassedException):
             nsexec(test_exception)
 
-    @skipIf(environ.get("CI") == "true", "Skipping test_namespace.py in CI")
     def test_user_namespace_func(self):
         self.assertEqual(nsexec(test_add_func, 1, 2), 3)
 
-    @skipIf(environ.get("CI") == "true", "Skipping test_namespace.py in CI")
     def test_user_namespace_kwargs(self):
         self.assertEqual(nsexec(test_add_kwargs, 1, 2, add1=3, add2=4), 7)
 
-    @skipIf(environ.get("CI") == "true", "Skipping test_namespace.py in CI")
     def test_user_namespace_uid_gid(self):
         self.assertEqual(nsexec(test_uid_gid), (0, 0))
 
-    @skipIf(environ.get("CI") == "true", "Skipping test_namespace.py in CI")
     def test_user_namespace_chroot(self):
         from pathlib import Path
         from tempfile import TemporaryDirectory


### PR DESCRIPTION
unshare/related are only available on linux systems with python 3.12+, add checks to ensure those conditions are met before attempting to import